### PR TITLE
Support `--nolegacy_external_runfiles`

### DIFF
--- a/perl/perl.bzl
+++ b/perl/perl.bzl
@@ -102,7 +102,10 @@ def transitive_deps(ctx, extra_files = [], extra_deps = []):
 
 def _include_paths(ctx):
     """Calculate the PERL5LIB paths for a perl_library rule's includes."""
-    package_root = (ctx.label.workspace_root + "/" + ctx.label.package).strip("/") or "."
+    workspace_root = ctx.label.workspace_root
+    if workspace_root.startswith("external/"):
+        workspace_root = "../" + workspace_root[9:]
+    package_root = (workspace_root + "/" + ctx.label.package).strip("/") or "."
     include_paths = [package_root] if "." in ctx.attr.includes else []
     include_paths.extend([package_root + "/" + include for include in ctx.attr.includes if include != "."])
     for dep in ctx.attr.deps:

--- a/perl/perl.bzl
+++ b/perl/perl.bzl
@@ -102,9 +102,11 @@ def transitive_deps(ctx, extra_files = [], extra_deps = []):
 
 def _include_paths(ctx):
     """Calculate the PERL5LIB paths for a perl_library rule's includes."""
-    workspace_root = ctx.label.workspace_root
-    if workspace_root.startswith("external/"):
-        workspace_root = "../" + workspace_root[9:]
+    workspace_name = ctx.label.workspace_name
+    if workspace_name:
+        workspace_root = "../" + workspace_name
+    else:
+        workspace_root = ""
     package_root = (workspace_root + "/" + ctx.label.package).strip("/") or "."
     include_paths = [package_root] if "." in ctx.attr.includes else []
     include_paths.extend([package_root + "/" + include for include in ctx.attr.includes if include != "."])


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/23574 is flipped for Bazel 8 but [`ctx.label.workspace_root`](https://bazel.build/rules/lib/builtins/Label.html#workspace_root) still includes an `external/` prefix. Replacing that with `../` makes rules_perl (and rules_cpan) work with Bazel 8 (https://github.com/bazelbuild/bazel-central-registry/issues/3056).