### PR TITLE
upgrade version of perl to evade CVE-2023-47100

### DIFF
--- a/platforms.bzl
+++ b/platforms.bzl
@@ -5,8 +5,8 @@ platforms = [
     struct(
         os = "darwin",
         cpu = "arm64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-arm64.tar.xz"],
-        sha256 = "285769f3c50c339fb59a3987b216ae3c5c573b95babe6875a1ef56fb178433da",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.38.2.0/perl-darwin-arm64.tar.xz"],
+        sha256 = "1a50fe40d8d61c875546ac00e8ade1d0093e1fdc7277ab008f37e3f43c0eef82",
         strip_prefix = "perl-darwin-arm64",
         exec_compatible_with = [
             "@platforms//os:osx",
@@ -16,8 +16,8 @@ platforms = [
     struct(
         os = "darwin",
         cpu = "amd64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-amd64.tar.xz"],
-        sha256 = "63bc5ee36f5394d71c50cca6cafdd333ee58f9eaa40bca63c85f9bd06f2c1fd6",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.38.2.0/perl-darwin-amd64.tar.xz"],
+        sha256 = "763245980b0b2a88111460d19aee08ce707045537ed7493c34a76868f495dd53",
         strip_prefix = "perl-darwin-amd64",
         exec_compatible_with = [
             "@platforms//os:osx",
@@ -27,8 +27,8 @@ platforms = [
     struct(
         os = "linux",
         cpu = "amd64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-linux-amd64.tar.xz"],
-        sha256 = "3bdffa9d7a3f97c0207314637b260ba5115b1d0829f97e3e2e301191a4d4d076",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.38.2.0/perl-linux-amd64.tar.xz"],
+        sha256 = "0878db5752ba6ca4bed437392ceddbde05d0455f32a546f6f49f69b54a297ac2",
         strip_prefix = "perl-linux-amd64",
         exec_compatible_with = [
             "@platforms//os:linux",
@@ -38,8 +38,8 @@ platforms = [
     struct(
         os = "linux",
         cpu = "arm64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-linux-arm64.tar.xz"],
-        sha256 = "6fa4ece99e790ecbc2861f6ecb7b52694c01c2eeb215b4370f16a3b12d952117",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.38.2.0/perl-linux-arm64.tar.xz"],
+        sha256 = "d4cef73296f3b68960ad3149212df10c903676fbcbe24ad0913681bd5032cd05",
         strip_prefix = "perl-linux-arm64",
         exec_compatible_with = [
             "@platforms//os:linux",


### PR DESCRIPTION
[Current and the latest version of rules_perl](https://github.com/bazelbuild/rules_perl/blob/main/platforms.bzl) are using Perl version 5.36.0.

This version is affected by CVE-2023-47100: from (including) 5.30.0 up to (excluding) 5.38.2

This PR upgrades the dependency to use a version of Perl without CVE-2023-47100 vulnerability on Linux and Mac. I do not have the ability to validate windows changes so did not upgrade the perl version on windows. I did test that genhtml was working correctly on linux and mac.