### PR TITLE
Update to 5.40.1.0

### DIFF
--- a/platforms.bzl
+++ b/platforms.bzl
@@ -52,10 +52,10 @@ platforms = [
         os = "windows",
         cpu = "x86_64",
         urls = [
-            "https://mirror.bazel.build/strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
-            "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
+            "https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_54001_64bit_UCRT/strawberry-perl-5.40.0.1-64bit-portable.zip",
+            "https://mirror.bazel.build/github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_54001_64bit_UCRT/strawberry-perl-5.40.0.1-64bit-portable.zip",
         ],
-        sha256 = "aeb973da474f14210d3e1a1f942dcf779e2ae7e71e4c535e6c53ebabe632cc98",
+        sha256 = "754f3e2a8e473dc68d1540c7802fb166a025f35ef18960c4564a31f8b5933907",
         strip_prefix = "",
         exec_compatible_with = [
             "@platforms//os:windows",

--- a/platforms.bzl
+++ b/platforms.bzl
@@ -1,12 +1,14 @@
 """platforms.bzl defines metadata about the different relocatable-perl versions
 """
 
+linux_version = "5.40.1.0"
+
 platforms = [
     struct(
         os = "darwin",
         cpu = "arm64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.38.2.0/perl-darwin-arm64.tar.xz"],
-        sha256 = "1a50fe40d8d61c875546ac00e8ade1d0093e1fdc7277ab008f37e3f43c0eef82",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-darwin-arm64.tar.xz".format(linux_version)],
+        sha256 = "e58b98338bc52f352dc95310363ab6c725897557512b90b593c70ea357f1b2ab",
         strip_prefix = "perl-darwin-arm64",
         exec_compatible_with = [
             "@platforms//os:osx",
@@ -16,8 +18,8 @@ platforms = [
     struct(
         os = "darwin",
         cpu = "amd64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.38.2.0/perl-darwin-amd64.tar.xz"],
-        sha256 = "763245980b0b2a88111460d19aee08ce707045537ed7493c34a76868f495dd53",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-darwin-amd64.tar.xz".format(linux_version)],
+        sha256 = "6e16d12f6a765cbb708ebcb6fe9c74f0d71e1d648bff0ff7b8d88134e54b736a",
         strip_prefix = "perl-darwin-amd64",
         exec_compatible_with = [
             "@platforms//os:osx",
@@ -27,8 +29,8 @@ platforms = [
     struct(
         os = "linux",
         cpu = "amd64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.38.2.0/perl-linux-amd64.tar.xz"],
-        sha256 = "0878db5752ba6ca4bed437392ceddbde05d0455f32a546f6f49f69b54a297ac2",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-linux-amd64.tar.xz".format(linux_version)],
+        sha256 = "cd3216bd72fa4fe3b76fc7f4e2f1004d75e42495d515c09b53d79cba3700dd7b",
         strip_prefix = "perl-linux-amd64",
         exec_compatible_with = [
             "@platforms//os:linux",
@@ -38,8 +40,8 @@ platforms = [
     struct(
         os = "linux",
         cpu = "arm64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/5.38.2.0/perl-linux-arm64.tar.xz"],
-        sha256 = "d4cef73296f3b68960ad3149212df10c903676fbcbe24ad0913681bd5032cd05",
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-linux-arm64.tar.xz".format(linux_version)],
+        sha256 = "01b3beb5e5f806a5447e42246b440e54a96c314284a68be89ff2b980ba4a4ec1",
         strip_prefix = "perl-linux-arm64",
         exec_compatible_with = [
             "@platforms//os:linux",
@@ -50,7 +52,7 @@ platforms = [
         os = "windows",
         cpu = "x86_64",
         urls = [
-            "https://mirror.bazel.build/strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
+            "https://mirror.bazel.build/strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip".format(linux_version),
             "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
         ],
         sha256 = "aeb973da474f14210d3e1a1f942dcf779e2ae7e71e4c535e6c53ebabe632cc98",

--- a/platforms.bzl
+++ b/platforms.bzl
@@ -1,13 +1,13 @@
 """platforms.bzl defines metadata about the different relocatable-perl versions
 """
 
-linux_version = "5.40.1.0"
+unix_version = "5.40.1.0"
 
 platforms = [
     struct(
         os = "darwin",
         cpu = "arm64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-darwin-arm64.tar.xz".format(linux_version)],
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-darwin-arm64.tar.xz".format(unix_version)],
         sha256 = "e58b98338bc52f352dc95310363ab6c725897557512b90b593c70ea357f1b2ab",
         strip_prefix = "perl-darwin-arm64",
         exec_compatible_with = [
@@ -18,7 +18,7 @@ platforms = [
     struct(
         os = "darwin",
         cpu = "amd64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-darwin-amd64.tar.xz".format(linux_version)],
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-darwin-amd64.tar.xz".format(unix_version)],
         sha256 = "6e16d12f6a765cbb708ebcb6fe9c74f0d71e1d648bff0ff7b8d88134e54b736a",
         strip_prefix = "perl-darwin-amd64",
         exec_compatible_with = [
@@ -29,7 +29,7 @@ platforms = [
     struct(
         os = "linux",
         cpu = "amd64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-linux-amd64.tar.xz".format(linux_version)],
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-linux-amd64.tar.xz".format(unix_version)],
         sha256 = "cd3216bd72fa4fe3b76fc7f4e2f1004d75e42495d515c09b53d79cba3700dd7b",
         strip_prefix = "perl-linux-amd64",
         exec_compatible_with = [
@@ -40,7 +40,7 @@ platforms = [
     struct(
         os = "linux",
         cpu = "arm64",
-        urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-linux-arm64.tar.xz".format(linux_version)],
+        urls = ["https://github.com/skaji/relocatable-perl/releases/download/{}/perl-linux-arm64.tar.xz".format(unix_version)],
         sha256 = "01b3beb5e5f806a5447e42246b440e54a96c314284a68be89ff2b980ba4a4ec1",
         strip_prefix = "perl-linux-arm64",
         exec_compatible_with = [
@@ -52,7 +52,7 @@ platforms = [
         os = "windows",
         cpu = "x86_64",
         urls = [
-            "https://mirror.bazel.build/strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip".format(linux_version),
+            "https://mirror.bazel.build/strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
             "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
         ],
         sha256 = "aeb973da474f14210d3e1a1f942dcf779e2ae7e71e4c535e6c53ebabe632cc98",


### PR DESCRIPTION
This PR updates the perl version for Linux and Mac, because RHEL9 does not ship `lincrypt.so.1` which prevents perl from running